### PR TITLE
Disable deterministic on pipeline commands

### DIFF
--- a/blurring_as_a_service/inference_pipeline/components/blur_images.py
+++ b/blurring_as_a_service/inference_pipeline/components/blur_images.py
@@ -26,6 +26,7 @@ aml_experiment_settings = BlurringAsAServiceSettings.set_from_yaml(config_path)[
     display_name="Blur images.",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
+    is_deterministic=False,
 )
 def blur_images(
     data_to_blur: Input(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821

--- a/blurring_as_a_service/inference_pipeline/components/detect_sensitive_data.py
+++ b/blurring_as_a_service/inference_pipeline/components/detect_sensitive_data.py
@@ -23,6 +23,7 @@ aml_experiment_settings = BlurringAsAServiceSettings.set_from_yaml(config_path)[
     display_name="Uses a training model to detect sensitive data that needs to be blurred.",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
+    is_deterministic=False,
 )
 def detect_sensitive_data(
     data_to_blur: Input(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821
@@ -49,6 +50,5 @@ def detect_sensitive_data(
         exist_ok=True,
         name="detection_result",
         imgsz=(2000, 4000),
-        # half=True, # Half can be enabled only if run on GPU.
         hide_labels=True,
     )

--- a/blurring_as_a_service/metadata_pipeline/components/convert_coco_to_yolo.py
+++ b/blurring_as_a_service/metadata_pipeline/components/convert_coco_to_yolo.py
@@ -25,6 +25,7 @@ aml_experiment_settings = BlurringAsAServiceSettings.set_from_yaml(config_path)[
     display_name="Convert coco to yolo",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
+    is_deterministic=False,
 )
 def convert_coco_to_yolo(
     input_data: Input(type=AssetTypes.URI_FILE), output_folder: Output(type=AssetTypes.URI_FOLDER)  # type: ignore # noqa: F821

--- a/blurring_as_a_service/metadata_pipeline/components/create_metadata.py
+++ b/blurring_as_a_service/metadata_pipeline/components/create_metadata.py
@@ -25,6 +25,7 @@ aml_experiment_settings = BlurringAsAServiceSettings.set_from_yaml(config_path)[
     display_name="Create metadata",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
+    is_deterministic=False,
 )
 def create_metadata(
     input_directory: Input(type=AssetTypes.URI_FOLDER), output_file: Output(type=AssetTypes.URI_FILE)  # type: ignore # noqa: F821

--- a/blurring_as_a_service/settings/settings_schema.py
+++ b/blurring_as_a_service/settings/settings_schema.py
@@ -23,6 +23,7 @@ class MetadataPipelineSpec(SettingsSpecModel):
 
 class TrainingPipelineSpec(SettingsSpecModel):
     inputs: Dict[str, str] = None
+    outputs: Dict[str, str] = None
     flags: List[str] = []
 
 

--- a/blurring_as_a_service/training_pipeline/components/train_model.py
+++ b/blurring_as_a_service/training_pipeline/components/train_model.py
@@ -23,6 +23,7 @@ settings = BlurringAsAServiceSettings.set_from_yaml(config_path)
     display_name="Train model",
     environment=f"azureml:{settings['aml_experiment_details']['env_name']}:{settings['aml_experiment_details']['env_version']}",
     code="../../../",
+    is_deterministic=False,
 )
 def train_model(
     mounted_dataset: Input(type=AssetTypes.URI_FOLDER), model_weights: Input(type=AssetTypes.URI_FOLDER), yolo_yaml_path: Output(type=AssetTypes.URI_FOLDER), trained_model: Output(type=AssetTypes.URI_FOLDER)  # type: ignore # noqa: F821


### PR DESCRIPTION
We want to re-run the inference pipeline steps every time without reusing results from past runs.