### PR TITLE
Inference pipeline with val.py

### DIFF
--- a/blurring_as_a_service/inference_pipeline/components/detect_and_blur_sensitive_data.py
+++ b/blurring_as_a_service/inference_pipeline/components/detect_and_blur_sensitive_data.py
@@ -74,7 +74,7 @@ def detect_and_blur_sensitive_data(
         weights=f"{model}/best.pt",
         data=f"{yolo_yaml_path}/pano.yaml",
         project=results_path,
-        batch_size=4,
+        batch_size=model_parameters["batch_size"],
         device=cuda_device,
         name="val_detection_results",
         imgsz=model_parameters["img_size"],

--- a/blurring_as_a_service/inference_pipeline/submit_inference_pipeline.py
+++ b/blurring_as_a_service/inference_pipeline/submit_inference_pipeline.py
@@ -21,6 +21,9 @@ def inference_pipeline(mounted_root_folder, relative_paths_files_to_blur, model)
     detect_and_blur_sensitive_data_step.outputs.results_path = Output(
         type="uri_folder", mode="rw_mount", path=outputs["results_path"]
     )
+    detect_and_blur_sensitive_data_step.outputs.yolo_yaml_path = Output(
+        type="uri_folder", mode="rw_mount", path=outputs["yolo_yaml_path"]
+    )
 
     return {}
 

--- a/blurring_as_a_service/settings/settings_schema.py
+++ b/blurring_as_a_service/settings/settings_schema.py
@@ -47,7 +47,7 @@ class WorkloadDistributionPipelineSpec(SettingsSpecModel):
 
 
 class InferenceModelParameters(SettingsSpecModel):
-    img_size = (2000, 4000)
+    # img_size = (2000, 4000)
     save_txt: bool = True
     exist_ok: bool = True
     half: bool = True

--- a/blurring_as_a_service/settings/settings_schema.py
+++ b/blurring_as_a_service/settings/settings_schema.py
@@ -53,6 +53,7 @@ class InferenceModelParameters(SettingsSpecModel):
     half: bool = True
     hide_labels: bool = True
     save_blurred_image: bool = True
+    batch_size: int = 1
 
 
 class InferencePipelineSpec(SettingsSpecModel):

--- a/blurring_as_a_service/settings/settings_schema.py
+++ b/blurring_as_a_service/settings/settings_schema.py
@@ -47,7 +47,7 @@ class WorkloadDistributionPipelineSpec(SettingsSpecModel):
 
 
 class InferenceModelParameters(SettingsSpecModel):
-    # img_size = (2000, 4000)
+    img_size: int = 4000
     save_txt: bool = True
     exist_ok: bool = True
     half: bool = True

--- a/config.example.yml
+++ b/config.example.yml
@@ -39,7 +39,7 @@ workload_distribution_pipeline:
 
 inference_pipeline:
   model_parameters:
-    img_size: (2000, 4000)
+    img_size: 4000
     save_txt: True
     exist_ok: True
     half: True
@@ -50,6 +50,7 @@ inference_pipeline:
     files_to_blur: "azureml://FILE_WITH_RELATIVE_PATHS_OF_BLUR_IMAGES"
     model: "azureml://NAMED_ASSET_URI_MODEL_WEIGHTS_FILE"
   outputs:
+    yolo_yaml_file: "azureml://FOLDER_PATH_WHERE_STORE_YAML_FILE_USED_BY_YOLO"
     results_path: "azureml://FOLDER_PATH_WHERE_STORE_BLURRED_IMAGES"
 
 performance_evaluation_pipeline:

--- a/config.example.yml
+++ b/config.example.yml
@@ -45,6 +45,7 @@ inference_pipeline:
     half: True
     hide_labels: True
     save_blurred_image: True
+    batch_size: 1
   inputs:
     root_folder: "azureml://FOLDER_PATH_TO_IMAGES_FOLDER"
     files_to_blur: "azureml://FILE_WITH_RELATIVE_PATHS_OF_BLUR_IMAGES"


### PR DESCRIPTION
### Description
Inference pipeline uses now the val.py with txt file in pano.yaml

### Related Jira Ticket
Please include the Jira ticket number and a brief description of the issue. For example:
- Ticket: adjusted inference pipeline work with this: [BS-147](https://cvteamamsterdam.atlassian.net/browse/BS-147?atlOrigin=eyJpIjoiM2M2NjQ1Y2QyYzM0NDNhNDk5OGY5MTBmNjhhNTkxNGIiLCJwIjoiaiJ9)
- Description: Add blur + save bbox data to val.py
